### PR TITLE
fix: load for /d/ (shared without a custom name) notebooks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
    "content_scripts": [
    {
-     "matches": ["https://observablehq.com/@*"],
+     "matches": ["https://observablehq.com/@*", "https://observablehq.com/d/*"],
      "css": [
      ],
      "js": [ 
@@ -25,7 +25,7 @@
     "downloads"
   ],
   "host_permissions": [ 
-    "https://observablehq.com/@*"
+    "https://observablehq.com/@*", "https://observablehq.com/d/*"
   ],
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
Hi!

I found it doesn't work for notebooks which aren't named so don't begin with `@`, for example:

https://observablehq.com/d/72b4a1a27d4497c2?collection=@declann/gemini

This fixes it.

Thanks for sharing this neat extension!

Declan